### PR TITLE
productモデル編集

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,7 +1,17 @@
 class Product < ApplicationRecord
+  
 belongs_to :shop, dependent: :destroy
 
 validates :name, presence: true
 validates :introduction, presence: true
 validates :price, presence: true
+
+enum limit:{
+  特になし:0,
+  １ヶ月:1,
+  ３ヶ月:2,
+  ６ヶ月:3,
+  １年:4,
+},_prefix: true
+
 end

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -22,9 +22,9 @@
                 = f.text_field :price, placeholder: '例）1000', class: 'form-box'
               .product-new--limit
                 %label{class: 'label-product'} 期限
-                %span{class: 'form-want'} 任意
+                %span{class: 'form-must'} 必須
                 %br
-                = f.date_select :limit
+                = f.select :limit, Product.limits.keys,{}
                 -# = f.collection_select :limit, Product.all, :id, :name
           .product-new__contents--right
             .product-new__contents--right--area

--- a/db/migrate/20200513224103_change_datatypedate_to_integer.rb
+++ b/db/migrate/20200513224103_change_datatypedate_to_integer.rb
@@ -1,0 +1,5 @@
+class ChangeDatatypedateToInteger < ActiveRecord::Migration[5.2]
+  def change
+    change_column :products, :limit, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_13_062926) do
+ActiveRecord::Schema.define(version: 2020_05_13_224103) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 2020_05_13_062926) do
   create_table "products", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.text "introduction", null: false
-    t.date "limit"
+    t.integer "limit"
     t.integer "price", null: false
     t.bigint "shop_id"
     t.datetime "created_at", null: false


### PR DESCRIPTION
# what
カラム型変更（:limit-dateからintegerへ）
enum採用

# why
transaction作成時の使用期限を設定しやすくするため。